### PR TITLE
Security Issue: Icingaweb2 shows API-Key in an unknown check status

### DIFF
--- a/check_pa/xml_reader.py
+++ b/check_pa/xml_reader.py
@@ -28,7 +28,11 @@ class XMLReader:
         :return: The XML output parsed by soup.
         """
         requests.packages.urllib3.disable_warnings()
-        resp = requests.get(self.build_request_url(), verify=False)
+        try:
+            resp = requests.get(self.build_request_url(), verify=False)
+        except requests.exceptions.ConnectionError:
+            raise CheckError('Expected status code: 200 (OK), returned'
+                             ' status code was: requests.exceptions.ConnectionError')
         if resp.status_code != 200:
             raise CheckError('Expected status code: 200 (OK), returned'
                              ' status code was: %d' % resp.status_code)


### PR DESCRIPTION
Hi Bro,
Icingaweb2 shows API-Key in an unknown check status.

![grafik](https://github.com/user-attachments/assets/e9fea327-b5fd-4018-a523-ccc52ff7517e)

It is fixed in the commit.


Best Regards
lowbob84