### PR TITLE
fix(licenses.py): handle licenses with Never expire correctly

### DIFF
--- a/check_pa/modules/licenses.py
+++ b/check_pa/modules/licenses.py
@@ -41,14 +41,16 @@ class License(np.Resource):
             name = Finder.find_item(license,"feature").strip()
             not_valid_after = Finder.find_item(license,'expires').strip()
             _log.info(name)
-            date_object = datetime.strptime(not_valid_after, '%B %d, %Y')
-            difference = date_object - get_now()
-            _log.debug('License "%s" difference: %s days' % (
-                name, difference.days))
-
-            if name not in self.exclude:
+            if not not_valid_after == 'Never':
+                date_object = datetime.strptime(not_valid_after, '%B %d, %Y')
+                difference = date_object - get_now()
+                _log.debug('License "%s" difference: %s days' % (
+                    name, difference.days))
+                if name not in self.exclude:
                     yield np.Metric(name, int(difference.days),
                                     context='license', uom="days")
+            else:
+                _log.debug('License "%s" never expires', name)
 
 
 class LicenseContext(np.Context):


### PR DESCRIPTION
If a license in the "licesnes" check mode is not expiring "Never" follwoing error will occour:
LICENSE UNKNOWN: ValueError: time data 'Never' does not match format '%B %d, %Y'

didn't check for what license.py and licenses.py are existing for, license.py is already handling it correctly. also implemented it in licenses.py
Result now:

LICENSE OK - All licenses (Advanced DNS Security,Advanced Threat Prevention,Advanced URL Filtering,Advanced WildFire License,GlobalProtect Gateway,Logging Service,PAN-DB URL Filtering,SD WAN,Standard,Threat Prevention,WildFire License) ok.
The next license will expire in 225 days.